### PR TITLE
Adding Custom Item Update

### DIFF
--- a/Util.cs
+++ b/Util.cs
@@ -37,10 +37,13 @@ namespace AFKReplacer
         {
             Timing.CallDelayed(3f, () =>
             {
-                player.AddItem(item);
                 if (customItemType is not null)
                 {
-                    customItemType.TrackedSerials.Add(item.Serial);
+                    customItemType.Give(player);
+                }
+                else
+                {
+                    player.AddItem(item);
                 }
             });
         }


### PR DESCRIPTION
- Changed the part where you add them to tracked serial to adding custom items the proper way.
- Fixed a bug where players when afk replacing someone with a custom weapon would get the basegame ammo amount in their gun rather than the custom amount.